### PR TITLE
update requirements.txt for webui dev branch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 segment_anything
 supervision
+addict
+yapf
+pycocotools


### PR DESCRIPTION
I've noticed for current clean dev branch sd-webui-segment-anything doesn't have few dependencies. They disappeared due to this PR, as I understood:
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/14425

They were in CodeFormer external repository dependencies which was deleted

I've tested any possible sam models, dino and autosam, and have found these 3


```log
File "/home/user/workspace/dev-stable-diffusion-webui/extensions/sd-webui-segment-anything/local_groundingdino/util/slconfig.py", line 13, in <module>
  from addict import Dict
ModuleNotFoundError: No module named 'addict'


File "/home/user/workspace/dev-stable-diffusion-webui/extensions/sd-webui-segment-anything/local_groundingdino/util/slconfig.py", line 14, in <module>
  from yapf.yapflib.yapf_api import FormatCode
ModuleNotFoundError: No module named 'yapf'


File "/home/user/workspace/dev-stable-diffusion-webui/extensions/sd-webui-segment-anything/sam_hq/automatic.py", line 99, in __init__
  from pycocotools import mask as mask_utils  # type: ignore # noqa: F401
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'pycocotools'
```