### PR TITLE
Fix sam hq and mobile sam loading with non cuda system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 models/*/*.pth
+models/*/*.pt
 __pycache__
 annotator

--- a/sam_hq/build_sam_hq.py
+++ b/sam_hq/build_sam_hq.py
@@ -64,7 +64,7 @@ def _load_sam_checkpoint(sam: Sam, checkpoint=None):
     sam.eval()
     if checkpoint is not None:
         with open(checkpoint, "rb") as f:
-            state_dict = torch.load(f)
+            state_dict = torch.load(f, map_location="cpu")
         info = sam.load_state_dict(state_dict, strict=False)
         print(info)
     for _, p in sam.named_parameters():


### PR DESCRIPTION
We found a problem that hq and mobile models cann't be loaded on AMD system with sam_device='cpu'

```log
...
File "C:\a1111\stable-diffusion-webui-directml\extensions\sd-webui-segment-anything\sam_hq\build_sam_hq.py", line 39, in build_sam_hq_vit_b
return _build_sam_hq(
File "C:\a1111\stable-diffusion-webui-directml\extensions\sd-webui-segment-anything\sam_hq\build_sam_hq.py", line 122, in _build_sam_hq
return _load_sam_checkpoint(sam, checkpoint)
File "C:\a1111\stable-diffusion-webui-directml\extensions\sd-webui-segment-anything\sam_hq\build_sam_hq.py", line 67, in _load_sam_checkpoint
state_dict = torch.load(f)
...
RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.
```

I think it's because of this: https://stackoverflow.com/questions/56369030/runtimeerror-attempting-to-deserialize-object-on-a-cuda-device

Regular SAM work fine, they have their own build functions:

```python
from segment_anything import build_sam_vit_h, build_sam_vit_l, build_sam_vit_b
```

Note, this patch doesn't mean hq and mobile models will be used only on cpu, here they are moved from 'cpu' into 'sam_device':

```python
    sam = sam_model_registry[model_type](checkpoint=sam_checkpoint_path)
    sam.to(device=sam_device)
```